### PR TITLE
Adding support for bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,41 @@ Example : **[http://samcome.github.io/webfont-medical-icons](http://samcome.gith
 SVGs, PNGs (64x64), Webfont (.eot, .ttf, .woff, .svg)
 
 ---
-#### Using Icon Fonts into your project
+### Using Icon Fonts into your project
 ---
-1. Copy the fonts folder
-`packages/webfont-medical-icons/fonts`
 
-2. Copy the css file
-`packages/webfont-medical-icons/wfmi-style.css`
 
-3. In the head html, reference the location to the css file
+---
+#### Install with bower
+---
+
+1. Install with bower
+`bower install webfont-medical-icons --save`
+
+2. In the head html, reference the location to the css file
 `<link rel="stylesheet" href="../css/wfmi-style.css">`
 
-4. Add classes to your elements
+3. Add classes to your elements
+`<span class="icon-neurology" aria-hidden="true"></span>`
+
+#### DONE!
+
+---
+#### Install manually
+---
+
+1. Download repo and extract files
+
+2. Copy the fonts folder
+`packages/webfont-medical-icons/fonts`
+
+3. Copy the css file
+`packages/webfont-medical-icons/wfmi-style.css`
+
+4. In the head html, reference the location to the css file
+`<link rel="stylesheet" href="../css/wfmi-style.css">`
+
+5. Add classes to your elements
 `<span class="icon-neurology" aria-hidden="true"></span>`
 
 #### DONE!

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,11 @@
+{
+  "name": "webfont-medical-icons",
+  "description": "72 ICONS (X2) specialized in the Clinical & Medical world FREE and easy to use!",
+  "main": "packages/webfont-medical-icons/wfmi-style.css",
+  "authors": [
+    "Samuel Frémondière"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/alsbury/webfont-medical-icons",
+  "moduleType": []
+}


### PR DESCRIPTION
I believe I made all the necessary changes to make this project available using bower. 

The repo would probably need a tag for 1.0.0 (http://semver.org/).

The repo needs to be registered with bower:

bower register webfont-medical-icons git@github.com:samcome/webfont-medical-icons.git

If this something you are not interested in doing, I can register the repo myself.

Thanks,
David