### PR TITLE
Arrange files to work better with build systems

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "webfont-medical-icons",
   "description": "72 ICONS (X2) specialized in the Clinical & Medical world FREE and easy to use!",
-  "main": "packages/webfont-medical-icons/wfmi-style.css",
+  "main": "packages/webfont-medical-icons/css/wfmi-style.css",
   "authors": [
     "Samuel Frémondière"
   ],

--- a/packages/webfont-medical-icons/css/wfmi-style.css
+++ b/packages/webfont-medical-icons/css/wfmi-style.css
@@ -1,10 +1,10 @@
 @font-face {
 	font-family: 'webfont-medical-icons';
-	src:url('fonts/webfont-medical-icons.eot');
-	src:url('fonts/webfont-medical-icons.eot?#iefix') format('embedded-opentype'),
-		url('fonts/webfont-medical-icons.ttf') format('truetype'),
-		url('fonts/webfont-medical-icons.woff') format('woff'),
-		url('fonts/webfont-medical-icons.svg#webfont-medical-icons') format('svg');
+	src:url('../fonts/webfont-medical-icons.eot');
+	src:url('../fonts/webfont-medical-icons.eot?#iefix') format('embedded-opentype'),
+		url('../fonts/webfont-medical-icons.ttf') format('truetype'),
+		url('../fonts/webfont-medical-icons.woff') format('woff'),
+		url('../fonts/webfont-medical-icons.svg#webfont-medical-icons') format('svg');
 	font-weight: normal;
 	font-style: normal;
 }


### PR DESCRIPTION
When using bower and a build system like gulp, files are usually output into a structure like:

`fonts/webfont-medical-icons.ttf`
`css/vendor.css`

Since the wfmi-style.css is at the same level with the fonts folder, its relative path to the fonts is: `url('fonts/webfont-medical-icons.ttf')`

So what I've done here is move wfmi-style.css into a new directory called css, updated its position in the bower.json file, and changed the urls to be relative to the fonts folder.
